### PR TITLE
feat: [정은선] 사용자는 마이페이지에서 멤버십 메뉴에 접근할 수 있다 [JSF-107]

### DIFF
--- a/mypage-app/src/App.tsx
+++ b/mypage-app/src/App.tsx
@@ -7,6 +7,7 @@ import AccountProfileEdit from "./pages/AccountProfileEdit.tsx";
 import InterviewResultList from "./pages/InterviewResultList.tsx";
 import InterviewResultDetail from "./pages/InterviewResultDetail.tsx";
 import AccountWithdrawal from "./pages/AccountWithdrawal.tsx";
+import MembershipPage from "./pages/MemebershipPage.tsx";
 
 import styled, { ThemeProvider, createGlobalStyle } from 'styled-components';
 import { getTheme, onThemeChange, type Theme as BridgeTheme } from '@jobspoon/theme-bridge';
@@ -84,6 +85,8 @@ export default function App() {
                         <Route path="interview/history/:id" element={<InterviewResultDetail />} />
                         {/* 회원탈퇴 */}
                         <Route path="withdrawal" element={<AccountWithdrawal />} />
+                        {/* 멤버십 */}
+                        <Route path="membership" element={<MembershipPage />} />
                     </Route>
                 </Routes>
             </AppShell>

--- a/mypage-app/src/components/layout/SideBar.tsx
+++ b/mypage-app/src/components/layout/SideBar.tsx
@@ -34,11 +34,11 @@ export default function SideBar() {
                     </li>
 
                     <li>
-                        <NavButton onClick={handleOpenModal}>
+                        <StyledNavLink to="membership">
                             <FaCrown className="icon" />
                             멤버십
                             {/* 하위에 내 구독 내역 나오도록 페이지 구성 */}
-                        </NavButton>
+                        </StyledNavLink>
                     </li>
 
                     <li>

--- a/mypage-app/src/components/layout/SideBar.tsx
+++ b/mypage-app/src/components/layout/SideBar.tsx
@@ -69,13 +69,6 @@ export default function SideBar() {
                     <Divider />
 
                     <li>
-                        <NavButton onClick={handleOpenModal}>
-                            <FaCog className="icon" />
-                            설정
-                        </NavButton>
-                    </li>
-
-                    <li>
                         <StyledNavLink to="withdrawal">
                             <FaSignOutAlt className="icon" />
                             회원탈퇴

--- a/mypage-app/src/components/modals/CreditUsageModal.tsx
+++ b/mypage-app/src/components/modals/CreditUsageModal.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import styled from "styled-components";
+
+interface CreditUsageModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export default function CreditUsageModal({ isOpen, onClose }: CreditUsageModalProps) {
+    return (
+        <Overlay isOpen={isOpen}>
+            <ModalBox isOpen={isOpen}>
+                <Header>
+                    <h3>크레딧 사용 안내</h3>
+                    <CloseButton onClick={onClose}>×</CloseButton>
+                </Header>
+
+                <Content>
+                    <ul>
+                        <li><strong>AI 모의면접</strong>: 5 크레딧 / 1회</li>
+                        <li><strong>문제풀이</strong>: 2 크레딧 / 1문제</li>
+                        <li><strong>스터디룸 개설</strong>: 10 크레딧 / 1회</li>
+                    </ul>
+                    <p>※ 크레딧은 결제일 기준 6개월간 유효합니다.</p>
+                </Content>
+
+                <Footer>
+                    <ConfirmButton onClick={onClose}>확인</ConfirmButton>
+                </Footer>
+            </ModalBox>
+        </Overlay>
+    );
+}
+
+/* ============= styled-components ============= */
+const Overlay = styled.div<{ isOpen: boolean }>`
+    position: fixed;
+    inset: 0;
+    background: ${({ isOpen }) => (isOpen ? "rgba(0, 0, 0, 0.4)" : "transparent")};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 999;
+
+    opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+    visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+    transition: all 0.3s ease-in-out;
+`;
+
+const ModalBox = styled.div<{ isOpen: boolean }>`
+    background: #fff;
+    padding: 20px;
+    border-radius: 12px;
+    width: 400px;
+    max-width: 90%;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.15);
+
+    transform: ${({ isOpen }) => (isOpen ? "scale(1)" : "scale(0.95)")};
+    transition: all 0.3s ease-in-out;
+`;
+
+const Header = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    h3 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 700;
+    }
+`;
+
+const CloseButton = styled.button`
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+`;
+
+const Content = styled.div`
+    margin: 16px 0;
+
+    ul {
+        margin: 0 0 12px;
+        padding-left: 20px;
+        font-size: 14px;
+        color: rgb(55, 65, 81);
+    }
+
+    p {
+        font-size: 13px;
+        color: rgb(107, 114, 128);
+    }
+`;
+
+const Footer = styled.div`
+    display: flex;
+    justify-content: flex-end;
+`;
+
+const ConfirmButton = styled.button`
+    padding: 8px 16px;
+    font-size: 14px;
+    background: rgb(59,130,246);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+
+    transition: background 0.2s ease-in-out;
+    &:hover {
+        background: rgb(37,99,235);
+    }
+`;

--- a/mypage-app/src/components/modals/RankGuideModal.tsx
+++ b/mypage-app/src/components/modals/RankGuideModal.tsx
@@ -9,11 +9,9 @@ type Props = {
 };
 
 export default function RankGuideModal({ isOpen, onClose }: Props) {
-    if (!isOpen) return null;
-
     return (
-        <Overlay>
-            <Modal>
+        <Overlay isOpen={isOpen}>
+            <Modal isOpen={isOpen}>
                 <Header>
                     <h2>랭크 가이드</h2>
                     <CloseButton onClick={onClose}>×</CloseButton>
@@ -37,16 +35,20 @@ export default function RankGuideModal({ isOpen, onClose }: Props) {
 }
 
 /* ================= styled-components ================= */
-const Overlay = styled.div`
+const Overlay = styled.div<{ isOpen: boolean }>`
     position: fixed;
     top: 0; left: 0;
     width: 100%; height: 100%;
-    background: rgba(0,0,0,0.4);
     display: flex; align-items: center; justify-content: center;
     z-index: 1000;
+
+    background: ${({ isOpen }) => (isOpen ? "rgba(0,0,0,0.4)" : "transparent")};
+    opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+    visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+    transition: all 0.3s ease-in-out;
 `;
 
-const Modal = styled.div`
+const Modal = styled.div<{ isOpen: boolean }>`
     background: white;
     padding: 20px;
     border-radius: 12px;
@@ -55,6 +57,9 @@ const Modal = styled.div`
     display: flex;
     flex-direction: column;
     gap: 16px;
+
+    transform: ${({ isOpen }) => (isOpen ? "scale(1)" : "scale(0.95)")};
+    transition: all 0.3s ease-in-out;
 `;
 
 const Header = styled.div`
@@ -103,6 +108,7 @@ const ConfirmButton = styled.button`
     border-radius: 6px;
     cursor: pointer;
 
+    transition: background 0.2s ease-in-out;
     &:hover {
         background: rgb(37, 99, 235);
     }

--- a/mypage-app/src/components/modals/TitleGuideModal.tsx
+++ b/mypage-app/src/components/modals/TitleGuideModal.tsx
@@ -9,11 +9,9 @@ type Props = {
 };
 
 export default function TitleGuideModal({ isOpen, onClose }: Props) {
-    if (!isOpen) return null;
-
     return (
-        <Overlay>
-            <ModalBox>
+        <Overlay isOpen={isOpen}>
+            <ModalBox isOpen={isOpen}>
                 <Header>
                     <h2>칭호 가이드</h2>
                     <CloseButton onClick={onClose}>×</CloseButton>
@@ -39,74 +37,82 @@ export default function TitleGuideModal({ isOpen, onClose }: Props) {
 }
 
 /* ================= styled-components ================= */
-const Overlay = styled.div`
-  position: fixed;
-  inset: 0;
-  background: rgba(0,0,0,0.4);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
+const Overlay = styled.div<{ isOpen: boolean }>`
+    position: fixed;
+    inset: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+
+    background: ${({ isOpen }) => (isOpen ? "rgba(0,0,0,0.4)" : "transparent")};
+    opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+    visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+    transition: all 0.3s ease-in-out;
 `;
 
-const ModalBox = styled.div`
-  background: white;
-  padding: 20px;
-  border-radius: 12px;
-  width: 400px;
-  max-width: 90%;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+const ModalBox = styled.div<{ isOpen: boolean }>`
+    background: white;
+    padding: 20px;
+    border-radius: 12px;
+    width: 400px;
+    max-width: 90%;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+
+    transform: ${({ isOpen }) => (isOpen ? "scale(1)" : "scale(0.95)")};
+    transition: all 0.3s ease-in-out;
 `;
 
 const Header = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
-  h2 {
-    font-size: 18px;
-    font-weight: 700;
-    margin: 0;
-  }
+    h2 {
+        font-size: 18px;
+        font-weight: 700;
+        margin: 0;
+    }
 `;
 
 const CloseButton = styled.button`
-  font-size: 20px;
-  border: none;
-  background: transparent;
-  cursor: pointer;
+    font-size: 20px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
 `;
 
 const Content = styled.div`
-  font-size: 14px;
-  line-height: 1.6;
+    font-size: 14px;
+    line-height: 1.6;
 
-  ul {
-    margin: 8px 0;
-    padding-left: 18px;
-  }
+    ul {
+        margin: 8px 0;
+        padding-left: 18px;
+    }
 
-  li {
-    margin-bottom: 4px;
-  }
+    li {
+        margin-bottom: 4px;
+    }
 `;
 
 const Footer = styled.div`
-  display: flex;
-  justify-content: flex-end;
+    display: flex;
+    justify-content: flex-end;
 `;
 
 const ConfirmButton = styled.button`
-  padding: 8px 16px;
-  background: rgb(59, 130, 246);
-  color: white;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
+    padding: 8px 16px;
+    background: rgb(59, 130, 246);
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
 
-  &:hover {
-    background: rgb(37, 99, 235);
-  }
+    transition: background 0.2s ease-in-out;
+    &:hover {
+        background: rgb(37, 99, 235);
+    }
 `;

--- a/mypage-app/src/components/modals/TrustScoreModal.tsx
+++ b/mypage-app/src/components/modals/TrustScoreModal.tsx
@@ -11,15 +11,14 @@ type Props = {
 };
 
 export default function TrustScoreModal({ isOpen, onClose, trust }: Props) {
-    if (!isOpen) return null;
-
     return (
-        <Overlay>
-            <Modal>
+        <Overlay isOpen={isOpen}>
+            <Modal isOpen={isOpen}>
                 <Header>
                     <h2>신뢰 점수 산정 기준</h2>
                     <CloseButton onClick={onClose}>×</CloseButton>
                 </Header>
+
                 <Content>
                     <h3>내 점수 현황</h3>
                     <ul>
@@ -90,27 +89,35 @@ export default function TrustScoreModal({ isOpen, onClose, trust }: Props) {
     );
 }
 
-/* styled-components (RankGuideModal 과 동일) */
-const Overlay = styled.div`
+/* ================= styled-components ================= */
+const Overlay = styled.div<{ isOpen: boolean }>`
     position: fixed;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    background: rgba(0,0,0,0.4);
-    display: flex; align-items: center; justify-content: center;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     z-index: 1000;
+
+    background: ${({ isOpen }) => (isOpen ? "rgba(0,0,0,0.4)" : "transparent")};
+    opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+    visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+    transition: all 0.3s ease-in-out;
 `;
 
-const Modal = styled.div`
+const Modal = styled.div<{ isOpen: boolean }>`
     background: white;
     padding: 20px;
     border-radius: 12px;
     width: 400px;
     max-width: 90%;
-    max-height: 80vh;      /* 🔹 화면 높이 80%까지만 */
-    overflow-y: auto;      /* 🔹 넘치면 스크롤 */
+    max-height: 80vh;      /* 화면 높이 80%까지만 */
+    overflow-y: auto;      /* 넘치면 스크롤 */
     display: flex;
     flex-direction: column;
     gap: 16px;
+
+    transform: ${({ isOpen }) => (isOpen ? "scale(1)" : "scale(0.95)")};
+    transition: all 0.3s ease-in-out;
 `;
 
 const Header = styled.div`
@@ -144,24 +151,6 @@ const Content = styled.div`
     li {
         margin-bottom: 4px;
     }
-
-    table {
-        width: 100%;
-        border-collapse: collapse;
-        margin-top: 12px;
-        font-size: 13px;
-    }
-
-    th, td {
-        border: 1px solid #ddd;
-        padding: 6px 8px;
-        text-align: left;
-    }
-
-    th {
-        background: #f9fafb;
-        font-weight: 600;
-    }
 `;
 
 const Footer = styled.div`
@@ -177,52 +166,53 @@ const ConfirmButton = styled.button`
     border-radius: 6px;
     cursor: pointer;
 
+    transition: background 0.2s ease-in-out;
     &:hover {
         background: rgb(37, 99, 235);
     }
 `;
 
 const Divider = styled.hr`
-  border: none;
-  border-top: 1px solid #e5e7eb;
-  margin: 16px 0;
+    border: none;
+    border-top: 1px solid #e5e7eb;
+    margin: 16px 0;
 `;
 
 const CardList = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-top: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 12px;
 `;
 
 const Card = styled.div`
     border: 1px solid #e5e7eb;
     border-radius: 8px;
     padding: 12px;
-    background: #fff;              /* 밝은 배경 */
-    box-shadow: 0 1px 3px rgba(0,0,0,0.05); /* 살짝 그림자 */
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
 `;
 
 const Title = styled.h4`
-  font-size: 15px;
-  font-weight: 600;
-  margin: 0 0 4px;
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0 0 4px;
 `;
 
 const Point = styled.p`
-  font-size: 13px;
-  font-weight: 500;
-  color: #2563eb;
-  margin: 0 0 4px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #2563eb;
+    margin: 0 0 4px;
 `;
 
 const Desc = styled.p`
-  font-size: 13px;
-  margin: 0 0 2px;
+    font-size: 13px;
+    margin: 0 0 2px;
 `;
 
 const Note = styled.p`
-  font-size: 12px;
-  color: #6b7280;
-  margin: 0;
+    font-size: 12px;
+    color: #6b7280;
+    margin: 0;
 `;

--- a/mypage-app/src/components/modals/WithdrawalConfirmModal.tsx
+++ b/mypage-app/src/components/modals/WithdrawalConfirmModal.tsx
@@ -2,17 +2,19 @@ import React from "react";
 import styled from "styled-components";
 
 interface WithdrawalConfirmModalProps {
+    isOpen: boolean;
     onClose: () => void;
     onConfirm: () => void;
 }
 
 export default function WithdrawalConfirmModal({
+                                                   isOpen,
                                                    onClose,
                                                    onConfirm,
                                                }: WithdrawalConfirmModalProps) {
     return (
-        <Overlay>
-            <ModalContent>
+        <Overlay isOpen={isOpen}>
+            <ModalContent isOpen={isOpen}>
                 <Title>정말 탈퇴하시겠습니까?</Title>
 
                 <Message>
@@ -31,7 +33,7 @@ export default function WithdrawalConfirmModal({
 
 /* ================== styled-components ================== */
 
-const Overlay = styled.div`
+const Overlay = styled.div<{ isOpen: boolean }>`
     position: fixed;
     inset: 0;
     display: flex;
@@ -39,16 +41,22 @@ const Overlay = styled.div`
     justify-content: center;
     z-index: 50;
 
-    background: rgba(0, 0, 0, 0.5);
+    background: ${({ isOpen }) => (isOpen ? "rgba(0, 0, 0, 0.5)" : "transparent")};
+    opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+    visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+    transition: all 0.3s ease-in-out;
 `;
 
-const ModalContent = styled.div`
+const ModalContent = styled.div<{ isOpen: boolean }>`
     background: white;
     border-radius: 12px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     padding: 24px;
-    width: 360px;   /* ✅ ServiceModal과 동일 */
+    width: 360px;
     text-align: center;
+
+    transform: ${({ isOpen }) => (isOpen ? "scale(1)" : "scale(0.95)")};
+    transition: all 0.3s ease-in-out;
 `;
 
 const Title = styled.h2`
@@ -72,29 +80,31 @@ const ButtonGroup = styled.div`
 `;
 
 const CancelButton = styled.button`
-  padding: 10px 20px;
-  background: #e5e7eb;
-  border: none;
-  color: #111827;
-  border-radius: 6px;
-  font-weight: 500;
-  cursor: pointer;
+    padding: 10px 20px;
+    background: #e5e7eb;
+    border: none;
+    color: #111827;
+    border-radius: 6px;
+    font-weight: 500;
+    cursor: pointer;
 
-  &:hover {
-    background: #d1d5db;
-  }
+    transition: background 0.2s ease-in-out;
+    &:hover {
+        background: #d1d5db;
+    }
 `;
 
 const DangerButton = styled.button`
-  padding: 10px 20px;
-  background: #dc2626;
-  border: none;
-  color: white;
-  border-radius: 6px;
-  font-weight: 600;
-  cursor: pointer;
+    padding: 10px 20px;
+    background: #dc2626;
+    border: none;
+    color: white;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
 
-  &:hover {
-    background: #b91c1c;
-  }
+    transition: background 0.2s ease-in-out;
+    &:hover {
+        background: #b91c1c;
+    }
 `;

--- a/mypage-app/src/components/modals/WritingModal.tsx
+++ b/mypage-app/src/components/modals/WritingModal.tsx
@@ -15,11 +15,9 @@ type Props = {
 };
 
 export default function WritingModal({ isOpen, onClose, writing }: Props) {
-    if (!isOpen) return null;
-
     return (
-        <Overlay>
-            <Modal>
+        <Overlay isOpen={isOpen}>
+            <Modal isOpen={isOpen}>
                 <Header>
                     <h2>글 작성 상세</h2>
                     <CloseButton onClick={onClose}>×</CloseButton>
@@ -45,16 +43,21 @@ export default function WritingModal({ isOpen, onClose, writing }: Props) {
 
 /* ================== styled-components ================== */
 
-const Overlay = styled.div`
+const Overlay = styled.div<{ isOpen: boolean }>`
     position: fixed;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    background: rgba(0,0,0,0.4);
-    display: flex; align-items: center; justify-content: center;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     z-index: 1000;
+
+    background: ${({ isOpen }) => (isOpen ? "rgba(0,0,0,0.4)" : "transparent")};
+    opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+    visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+    transition: all 0.3s ease-in-out;
 `;
 
-const Modal = styled.div`
+const Modal = styled.div<{ isOpen: boolean }>`
     background: white;
     padding: 20px;
     border-radius: 12px;
@@ -65,6 +68,9 @@ const Modal = styled.div`
     display: flex;
     flex-direction: column;
     gap: 16px;
+
+    transform: ${({ isOpen }) => (isOpen ? "scale(1)" : "scale(0.95)")};
+    transition: all 0.3s ease-in-out;
 `;
 
 const Header = styled.div`
@@ -119,6 +125,7 @@ const ConfirmButton = styled.button`
     border-radius: 6px;
     cursor: pointer;
 
+    transition: background 0.2s ease-in-out;
     &:hover {
         background: rgb(37, 99, 235);
     }

--- a/mypage-app/src/pages/AccountProfileEdit.tsx
+++ b/mypage-app/src/pages/AccountProfileEdit.tsx
@@ -2,9 +2,8 @@
 
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import { FaPhone, FaEnvelope } from "react-icons/fa";
+import { FaPhone, FaEnvelope, FaLock } from "react-icons/fa";
 import { useOutletContext } from "react-router-dom";
-
 import defaultProfile from "../assets/default_profile.png";
 import ServiceModal from "../components/modals/ServiceModal.tsx";
 import {
@@ -26,7 +25,7 @@ type OutletContextType = {
 export default function AccountProfileEdit() {
     const { profile, refreshProfile } = useOutletContext<OutletContextType>();
 
-    // 모달 상태
+    // 서비스 모달 상태
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     // 닉네임 수정 상태
@@ -34,17 +33,29 @@ export default function AccountProfileEdit() {
     const [tempNickname, setTempNickname] = useState("");
     const [error, setError] = useState<string | null>(null);
 
+    // 랭크 상태
     const [ranks, setRanks] = useState<HistoryItem[]>([]);
     const [showRanks, setShowRanks] = useState(false);
 
+    // 칭호 상태
     const [titles, setTitles] = useState<HistoryItem[]>([]);
     const [showTitles, setShowTitles] = useState(false);
+
+    // 프로필 공개 여부 상태
+    const [isProfilePublic, setIsProfilePublic] = useState(true);
 
     // TODO: AccountProfile API 나오면 교체
     const [accountInfo] = useState({
         phone: "",
     });
 
+    // TODO: AccountProfile API 나오면 교체
+    const [consent, setConsent] = useState({
+        phone: true,
+        email: false,
+    });
+
+    // 랭크, 칭호 이력 가져오기
     useEffect(() => {
         const token = localStorage.getItem("userToken");
         if (!token) return;
@@ -91,12 +102,6 @@ export default function AccountProfileEdit() {
         }
     };
 
-    // TODO: AccountProfile API 나오면 교체
-    const [consent] = useState({
-        phone: true,
-        email: false,
-    });
-
     /** 닉네임 수정 시작 */
     const handleStartEdit = () => {
         if (profile) {
@@ -129,6 +134,23 @@ export default function AccountProfileEdit() {
     /** 모달 열기 */
     const openModal = () => {
         setIsModalOpen(true);
+    };
+
+    // 토글 핸들러
+    const handleToggleProfilePublic = () => {
+        setIsProfilePublic((prev) => !prev);
+        setIsModalOpen(true); // 안내 모달도 같이 열림
+        // TODO: 나중에 API 연동
+    };
+
+    // 토글 핸들러
+    const handleToggleConsent = (key: "phone" | "email") => {
+        setConsent((prev) => ({
+            ...prev,
+            [key]: !prev[key],
+        }));
+        setIsModalOpen(true); // 안내 모달도 같이 열기
+        // TODO: 나중에 API 연동
     };
 
     if (!profile) {
@@ -195,6 +217,11 @@ export default function AccountProfileEdit() {
                             <span>{profile.email}</span>
                             <ActionLink onClick={openModal}>수정</ActionLink>
                         </InfoItem>
+                        <InfoItem>
+                            <FaLock style={{ color: "#6b7280", marginRight: "8px" }} />
+                            <span>비밀번호</span>
+                            <ActionLink onClick={openModal}>변경</ActionLink>
+                        </InfoItem>
                     </BottomRow>
                 </InfoCard>
             </Section>
@@ -208,10 +235,9 @@ export default function AccountProfileEdit() {
                             <span>스터디 모임 프로필 공개</span>
                         </Left>
                         <ToggleSwitch
-                            checked={profile?.isProfilePublic ?? true}
-                            onClick={openModal}
-                        >
-                            <span>{profile?.isProfilePublic ? "ON" : "OFF"}</span>
+                            checked={isProfilePublic}
+                            onClick={handleToggleProfilePublic}>
+                            <span>{isProfilePublic ? "ON" : "OFF"}</span>
                         </ToggleSwitch>
                     </ConsentRow>
                 </ConsentCard>
@@ -228,8 +254,7 @@ export default function AccountProfileEdit() {
                         </Left>
                         <ToggleSwitch
                             checked={consent.phone}
-                            onClick={openModal}
-                        >
+                            onClick={() => handleToggleConsent("phone")}>
                             <span>{consent.phone ? "ON" : "OFF"}</span>
                         </ToggleSwitch>
                     </ConsentRow>
@@ -243,8 +268,7 @@ export default function AccountProfileEdit() {
                         </Left>
                         <ToggleSwitch
                             checked={consent.email}
-                            onClick={openModal}
-                        >
+                            onClick={() => handleToggleConsent("email")}>
                             <span>{consent.email ? "ON" : "OFF"}</span>
                         </ToggleSwitch>
                     </ConsentRow>

--- a/mypage-app/src/pages/AccountProfileEdit.tsx
+++ b/mypage-app/src/pages/AccountProfileEdit.tsx
@@ -28,8 +28,6 @@ export default function AccountProfileEdit() {
 
     // 모달 상태
     const [isModalOpen, setIsModalOpen] = useState(false);
-    // modalType 타입 확장
-    const [modalType, setModalType] = useState<"phone" | "email" | "photo" | null>(null);
 
     // 닉네임 수정 상태
     const [isEditingNickname, setIsEditingNickname] = useState(false);
@@ -45,7 +43,6 @@ export default function AccountProfileEdit() {
     // TODO: AccountProfile API 나오면 교체
     const [accountInfo] = useState({
         phone: "",
-        email: "TestUser01@kakao.com",
     });
 
     useEffect(() => {
@@ -130,8 +127,7 @@ export default function AccountProfileEdit() {
     };
 
     /** 모달 열기 */
-    const openModal = (type: "phone" | "email" | "photo") => {
-        setModalType(type);
+    const openModal = () => {
         setIsModalOpen(true);
     };
 
@@ -180,7 +176,7 @@ export default function AccountProfileEdit() {
                             ) : (
                                 <SmallButton onClick={handleStartEdit}>별명 수정</SmallButton>
                             )}
-                            <SmallButton onClick={() => openModal("photo")}>사진 변경</SmallButton>
+                            <SmallButton onClick={openModal}>사진 변경</SmallButton>
                         </ButtonGroup>
                     </TopRow>
 
@@ -190,17 +186,35 @@ export default function AccountProfileEdit() {
                         <InfoItem>
                             <FaPhone style={{ color: "#6b7280", marginRight: "8px" }} />
                             <span>{accountInfo.phone || "본인확인 번호 없음"}</span>
-                            <ActionLink onClick={() => openModal("phone")}>
+                            <ActionLink onClick={openModal}>
                                 {accountInfo.phone ? "수정" : "등록"}
                             </ActionLink>
                         </InfoItem>
                         <InfoItem>
                             <FaEnvelope style={{ color: "#6b7280", marginRight: "8px" }} />
                             <span>{profile.email}</span>
-                            <ActionLink onClick={() => openModal("email")}>수정</ActionLink>
+                            <ActionLink onClick={openModal}>수정</ActionLink>
                         </InfoItem>
                     </BottomRow>
                 </InfoCard>
+            </Section>
+
+            {/* 프로필 공개 여부 */}
+            <Section>
+                <SectionTitle>프로필 공개 설정</SectionTitle>
+                <ConsentCard>
+                    <ConsentRow>
+                        <Left>
+                            <span>스터디 모임 프로필 공개</span>
+                        </Left>
+                        <ToggleSwitch
+                            checked={profile?.isProfilePublic ?? true}
+                            onClick={openModal}
+                        >
+                            <span>{profile?.isProfilePublic ? "ON" : "OFF"}</span>
+                        </ToggleSwitch>
+                    </ConsentRow>
+                </ConsentCard>
             </Section>
 
             {/* 프로모션 정보수신 동의 */}
@@ -214,7 +228,7 @@ export default function AccountProfileEdit() {
                         </Left>
                         <ToggleSwitch
                             checked={consent.phone}
-                            onClick={() => openModal("phone")}
+                            onClick={openModal}
                         >
                             <span>{consent.phone ? "ON" : "OFF"}</span>
                         </ToggleSwitch>
@@ -229,7 +243,7 @@ export default function AccountProfileEdit() {
                         </Left>
                         <ToggleSwitch
                             checked={consent.email}
-                            onClick={() => openModal("email")}
+                            onClick={openModal}
                         >
                             <span>{consent.email ? "ON" : "OFF"}</span>
                         </ToggleSwitch>

--- a/mypage-app/src/pages/AccountWithdrawal.tsx
+++ b/mypage-app/src/pages/AccountWithdrawal.tsx
@@ -84,12 +84,11 @@ export default function AccountWithdrawal() {
             </ButtonGroup>
 
             {/* 확인 모달 */}
-            {showConfirm && (
-                <WithdrawalConfirmModal
-                    onClose={() => setShowConfirm(false)}
-                    onConfirm={handleConfirm}
-                />
-            )}
+            <WithdrawalConfirmModal
+                isOpen={showConfirm}
+                onClose={() => setShowConfirm(false)}
+                onConfirm={handleConfirm}
+            />
 
             {/* 서비스 준비중 모달 */}
             {showServiceModal && (

--- a/mypage-app/src/pages/MemebershipPage.tsx
+++ b/mypage-app/src/pages/MemebershipPage.tsx
@@ -1,0 +1,243 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import ServiceModal from "../components/modals/ServiceModal.tsx";
+import CreditUsageModal from "../components/modals/CreditUsageModal.tsx";
+
+// 운영 중인 크레딧 상품 (mock)
+const credits = [
+    { id: 1, name: "10 크레딧", amount: 10, price: 5000, tag: "체험용" },
+    { id: 2, name: "50 크레딧", amount: 50, price: 20000, tag: "꾸준히 사용하는 분께 추천" },
+    { id: 3, name: "100 크레딧", amount: 100, price: 35000, tag: "헤비 유저 전용" },
+];
+
+// 내 크레딧 현황 (mock)
+const myCredits = {
+    balance: 72,
+    lastUsed: "2025-09-14",
+    expiry: "2026-03-01",
+    usageHistory: [
+        { date: "2025-09-14", action: "AI 모의면접", cost: 5 },
+        { date: "2025-09-10", action: "문제풀이", cost: 2 },
+        { date: "2025-09-05", action: "스터디룸 개설", cost: 10 },
+        { date: "2025-08-30", action: "문제풀이", cost: 3 },
+        { date: "2025-08-25", action: "AI 모의면접", cost: 5 },
+    ],
+};
+
+export default function MembershipPage() {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [usageModalOpen, setUsageModalOpen] = useState(false);
+
+    return (
+        <>
+            {/* 운영 중인 크레딧 상품 */}
+            <Section>
+                <SectionHeader>
+                    <SectionTitle>크레딧 충전하기</SectionTitle>
+                    <InfoButton onClick={() => setUsageModalOpen(true)}>사용처 안내</InfoButton>
+                </SectionHeader>
+                <SectionDesc>
+                    크레딧은 AI 모의면접, 문제풀이, 스터디룸 개설 등에 사용할 수 있습니다.
+                </SectionDesc>
+                <PlanGrid>
+                    {credits.map((credit) => (
+                        <PlanCard key={credit.id}>
+                            <h3>{credit.name}</h3>
+                            <p className="price">{credit.price.toLocaleString()}원</p>
+                            <TagBadge>{credit.tag}</TagBadge>
+                            <DetailButton onClick={() => setIsModalOpen(true)}>
+                                구매하기
+                            </DetailButton>
+                        </PlanCard>
+                    ))}
+                </PlanGrid>
+            </Section>
+
+            {/* 내 크레딧 현황 */}
+            <Section>
+                <SectionTitle>내 크레딧</SectionTitle>
+                <SubscriptionBox>
+                    <p>
+                        보유 크레딧: <strong>{myCredits.balance}개</strong>
+                    </p>
+                    <p>마지막 사용일: {myCredits.lastUsed}</p>
+                    <p>만료일: {myCredits.expiry}</p>
+                    <CancelButton onClick={() => setIsModalOpen(true)}>
+                        환불 요청
+                    </CancelButton>
+                </SubscriptionBox>
+            </Section>
+
+            {/* 사용 내역 */}
+            <Section>
+                <SectionTitle>사용 내역</SectionTitle>
+                <UsageList>
+                    {myCredits.usageHistory.map((u, i) => (
+                        <UsageItem key={i}>
+                            <span>{u.date}</span>
+                            <span>{u.action}</span>
+                            <span>-{u.cost} 크레딧</span>
+                        </UsageItem>
+                    ))}
+                </UsageList>
+            </Section>
+
+            {/* 서비스 모달 */}
+            <ServiceModal
+                isOpen={isModalOpen}
+                onClose={() => setIsModalOpen(false)}
+            />
+
+            {/* 사용처 안내 모달 */}
+            <CreditUsageModal
+                isOpen={usageModalOpen}
+                onClose={() => setUsageModalOpen(false)}
+            />
+        </>
+    );
+}
+
+/* ================= styled-components ================= */
+const Section = styled.section`
+    padding: 24px;
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    background: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    margin-bottom: 20px;
+`;
+
+const SectionHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const SectionTitle = styled.h2`
+    font-size: 18px;
+    font-weight: 700;
+    color: rgb(17, 24, 39);
+`;
+
+const SectionDesc = styled.p`
+    font-size: 14px;
+    color: rgb(107, 114, 128);
+    margin-top: -8px;
+    margin-bottom: 16px;
+`;
+
+const PlanGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 16px;
+`;
+
+const PlanCard = styled.div`
+    background: rgb(249, 250, 251);
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+
+    display: flex;               /* flexbox */
+    flex-direction: column;      /* 세로 배치 */
+
+    h3 {
+        font-size: 16px;
+        font-weight: 600;
+        color: rgb(17, 24, 39);
+        margin-bottom: 8px;
+    }
+
+    .price {
+        font-size: 14px;
+        font-weight: 500;
+        color: rgb(59, 130, 246);
+        margin-bottom: 6px;
+    }
+
+    .tag {
+        font-size: 13px;
+        font-weight: 500;
+        color: rgb(59, 130, 246);
+        background: rgba(59, 130, 246, 0.1);
+        padding: 4px 10px;
+        border-radius: 999px;
+        display: inline-block;
+        width: fit-content;
+    }
+`;
+
+const TagBadge = styled.span`
+    display: inline-block;        /* 블록 전체 말고 글자만큼 */
+    width: fit-content;           /* 글씨 크기만큼만 차지 */
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    color: rgb(59, 130, 246);
+    background: rgba(59, 130, 246, 0.1);
+    border-radius: 999px;         /* pill 형태 */
+    margin-bottom: 12px;
+`;
+
+const SubscriptionBox = styled.div`
+    background: rgb(249, 250, 251);
+    border-radius: 12px;
+    padding: 20px;
+    font-size: 14px;
+    color: rgb(55, 65, 81);
+
+    p {
+        margin-bottom: 6px;
+    }
+
+    strong {
+        font-weight: 700;
+        color: rgb(17, 24, 39);
+    }
+`;
+
+const DetailButton = styled.button`
+    margin-top: auto;             /* 버튼을 맨 아래로 */
+    align-self: flex-end;         /* 오른쪽 끝으로 */
+    padding: 8px 12px;
+    font-size: 13px;
+    background: rgb(59, 130, 246);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+`;
+
+const CancelButton = styled(DetailButton)`
+    background: rgb(239, 68, 68); /* 빨강 계열 */
+    margin-top: 12px;
+`;
+
+const UsageList = styled.div`
+    max-height: 200px;
+    overflow-y: auto;
+`;
+
+const UsageItem = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+  font-size: 14px;
+  border-bottom: 1px solid #eee;
+`;
+
+const InfoButton = styled.button`
+  font-size: 13px;
+  padding: 6px 12px;
+  background: rgb(243, 244, 246);
+  color: rgb(55, 65, 81);
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+
+  &:hover {
+    background: rgb(229, 231, 235);
+  }
+`;


### PR DESCRIPTION
- 마이페이지 사이드바에서 접근 가능한 멤버십 메뉴 페이지 추가
- 운영 중인 크레딧 상품 mock 데이터 구성 (체험용/꾸준히/헤비 유저 전용)
- 내 크레딧 현황(보유량/만료일/마지막 사용일) 및 사용 내역 mock 표시
- 구매/환불 버튼 클릭 시 공용 ServiceModal 연결
- '사용처 안내' 버튼 추가 및 CreditUsageModal 신규 생성
- 대시보드 Section 스타일 재사용하여 일관된 UI 적용
- TagBadge(pill) 스타일로 추천 유형 강조